### PR TITLE
Fixed Typo

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -164,6 +164,15 @@
       "contributions": [
         "doc"
       ]
+    },
+    {
+      "login": "devjhex",
+      "name": "Jonah Ssegawa",
+      "avatar_url": "https://avatars.githubusercontent.com/u/124887722?v=4",
+      "profile": "https://github.com/devjhex",
+      "contributions": [
+        "doc"
+      ]
     }
   ],
   "contributorsPerLine": 7

--- a/README.md
+++ b/README.md
@@ -917,7 +917,7 @@ Thanks goes to these wonderful people
   <tr>
     <td align="center"><a href="https://zoranjambor.com/"><img src="https://avatars.githubusercontent.com/u/515906?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Zoran Jambor</b></sub></a><br /><a href="https://github.com/codingknite/frontend-development/commits?author=ZoranJambor" title="Documentation">📖</a></td>
     <td align="center"><a href="https://github.com/jenniferfu0811"><img src="https://avatars.githubusercontent.com/u/25816882?v=4?s=100" width="100px;" alt=""/><br /><sub><b>jenniferfu0811</b></sub></a><br /><a href="https://github.com/codingknite/frontend-development/commits?author=jenniferfu0811" title="Documentation">📖</a></td>
-    <td align="center"><a href="https://twitter.com/gvrizzo"><img src="https://avatars.githubusercontent.com/u/7696343?v=4&s=100" width="100px;" alt=""/><br /><sub><b>gvrizzo</b></sub></a><br /><a href="https://github.com/codingknite/frontend-development/commits?author=guivr" title="Documentation">📖</a></td>
+    <td align="center"><a href="https://github.com/devjhex"><img src="https://avatars.githubusercontent.com/u/124887722?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Jonah Ssegawa</b></sub></a><br /><a href="https://github.com/codingknite/frontend-development/commits?author=devjhex" title="Documentation">📖</a></td>
   </tr>
 </table>
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Resources labelled with 💵 indicate that the resource is a paid resource.
 
 If you're just starting, you DON'T need to use every resource on this list. It is practically impossible. Use this as a reference. It is not a guide.
 
-## Contibuting
+## Contributing
 
 We Invite as many contributions as possible.
 


### PR DESCRIPTION
Fixed typo on line  15 of the README file,
```## Contibuting```  --> ```## Contributing```

Fixed typo on line 15 of the README file so as to focus on the content rather than the typo (contibuting-> contributing)
The request makes changes to the word ```contibuting``` to ```contributing```. It makes grammatical fixes to the documentation for other users to read with ease and understanding.